### PR TITLE
fix bug for long encode & decode

### DIFF
--- a/lib/avro/datum.php
+++ b/lib/avro/datum.php
@@ -310,6 +310,8 @@ class AvroIOBinaryEncoder
     {
       $str .= chr(($n & 0x7F) | 0x80);
       $n >>= 7;
+      // High Bit Must Be Zero
+      $n = $n & ~(0x7F << 57);
     }
     $str .= chr($n);
     return $str;
@@ -882,7 +884,9 @@ class AvroIOBinaryDecoder
       $n |= (($b & 0x7f) << $shift);
       $shift += 7;
     }
-    return (($n >> 1) ^ -($n & 1));
+    // Right Move High Bit Must Be Zero;
+    $highBitZero = ~(1 << 63);
+    return ((($n >> 1) & $highBitZero) ^ -($n & 1));
   }
 
   /**


### PR DESCRIPTION
Hi friend,

I find a bug when encode / decode longint data.
When longint 2nd bit is one,  after move first bit to end bit, the result  is negative number.
So, if we right move this number, the high bit is one, not zero. We can't finsh loop with (0 != ($n & ~0x7F)).
Decode longint is same as encode longint.

Thanks for you tools, it's useful for me. If you think this request is right, merge and publish a new tag with composer, I will use it in my project.

Best wish with you.
