### PR TITLE
Fix handling of default value `null` in records

### DIFF
--- a/lib/avro/schema.php
+++ b/lib/avro/schema.php
@@ -1450,7 +1450,7 @@ class AvroField extends AvroSchema
     $avro[AvroSchema::TYPE_ATTR] = ($this->is_type_from_schemata)
       ? $this->type->qualified_name() : $this->type->to_avro();
 
-    if (isset($this->default))
+    if ($this->has_default)
       $avro[AvroField::DEFAULT_ATTR] = $this->default;
 
     if ($this->order)

--- a/test/SchemaTest.php
+++ b/test/SchemaTest.php
@@ -409,6 +409,11 @@ class SchemaTest extends PHPUnit_Framework_TestCase
     {"type":"record", "name":"foo", "doc":"doc string",
      "fields":[{"name":"bar", "type":"int", "order":"bad"}]}
 ', false);
+     // `"default":null` should not be lost in `to_avro`.
+     $record_examples []= new SchemaExample(
+        '{"type":"record","name":"foo","fields":[{"name":"bar","type":["null","string"],"default":null}]}',
+        true,
+        '{"type":"record","name":"foo","fields":[{"name":"bar","type":["null","string"],"default":null}]}');
 
     self::$examples = array_merge($primitive_examples,
                                   $fixed_examples,


### PR DESCRIPTION
`null` default values in record fields are not handled properly.

example:
```php
$schema_json = <<<_JSON
{
    "name": "member",
    "type": "record",
    "fields":[
        {"name": "name", "type": ["string", "null"], "default": null}
    ]
}
_JSON;
$schema = AvroSchema::parse($schema_json);
echo (string)($schema) . "\n";
```

results in:
```
{"type":"record","name":"member","fields":[{"name":"name","type":["string","null"]}]}
```

note how `"default": null` is lost

this pull request fixes that


