### PR TITLE
Handle JSON decode errors better in AvroSchema::parse

### DIFF
--- a/lib/avro/schema.php
+++ b/lib/avro/schema.php
@@ -298,7 +298,10 @@ class AvroSchema
   public static function parse($json)
   {
     $schemata = new AvroNamedSchemata();
-    return self::real_parse(json_decode($json, true), null, $schemata);
+    $avro = json_decode($json, true);
+    if (json_last_error() !== JSON_ERROR_NONE)
+      throw new AvroSchemaParseException("JSON decode error " . json_last_error() . ": " . json_last_error_msg());
+    return self::real_parse($avro, null, $schemata);
   }
 
   /**


### PR DESCRIPTION
Throw exception instead of blindly working with NULL value

gerrit ticket: https://gerrit.wikimedia.org/r/c/avro-php/+/460909