### PR TITLE
Ported Flix.TECH fork bug fixes

### DIFF
--- a/lib/avro/datum.php
+++ b/lib/avro/datum.php
@@ -1018,7 +1018,7 @@ class AvroIOBinaryDecoder
   protected function skip_long()
   {
     $b = ord($this->next_byte());
-    while (0 != ($b & 0x80))
+    while ('' == $b || 0 != ($b & 0x80))
       $b = ord($this->next_byte());
   }
 

--- a/lib/avro/io.php
+++ b/lib/avro/io.php
@@ -208,8 +208,10 @@ class AvroStringIO extends AvroIO
   {
     $this->check_closed();
     $read='';
-    for($i=$this->current_index; $i<($this->current_index+$len); $i++) 
+    for ($i=$this->current_index; $i<($this->current_index+$len); $i++) {
+      if (!isset($this->string_buffer[$i])) continue;
       $read .= $this->string_buffer[$i];
+    }
     if (strlen($read) < $len)
       $this->current_index = $this->length();
     else


### PR DESCRIPTION
[Flix.TECH has recently decided ](https://github.com/flix-tech/avro-php/pull/2#issuecomment-436769576 )to deprecate their own fork of the avro-php library in order to rely on yours in their [avro serializer library](https://github.com/flix-tech/avro-serde-php).

However, their fork does provide bug fixes that are not present in yours.

This PR is an attempt to fix this gap by bringing these bug fixes within your fork.


The two Flix.TECH commits are:

- https://github.com/flix-tech/avro-php/commit/d8ab41cece70a5c2fddb3c060eb50e6e5863f8ce
- https://github.com/flix-tech/avro-php/commit/d05e121588217f75984e4373b535d82afd4b5d53


I am solely a user of the Flix.TECH libraries (and yours as well by transitivity), so I cannot make much decision here.
However, I can say that it would be much appreciated if you were able to take a bit of time to analyze what bugs are actually being fixed here and to take the best move to fix them.

I'm having trouble debugging the avro lib source code, thus haven't written any tests to reproduce these bugs (although I was able to reproduce the `Notice: Uninitialized string offset: 6 in /app/vendor/wikimedia/avro/lib/avro/io.php on line 213` with a fairly simple schema)... Sorry about that!

Thanks for your work and let me know if I can help!
